### PR TITLE
Add test for excluded package handling in PluginClassLoader

### DIFF
--- a/src/test/java/com/plugin/loader/PluginClassLoaderTest.java
+++ b/src/test/java/com/plugin/loader/PluginClassLoaderTest.java
@@ -2,10 +2,19 @@ package com.plugin.loader;
 
 
 import org.junit.jupiter.api.Test;
+import java.net.URL;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class PluginClassLoaderTest {
     @Test
     public void TestLoaderClass() {
         System.out.println(1);
+    }
+
+    @Test
+    public void shouldNotOverrideExcludedPackages() throws ClassNotFoundException {
+        PluginClassLoader classLoader = new PluginClassLoader(new URL[0], ClassLoader.getSystemClassLoader());
+        Class<?> clazz = classLoader.loadClass("java.lang.String");
+        assertNull(clazz.getClassLoader());
     }
 }


### PR DESCRIPTION
## Summary
- add `shouldNotOverrideExcludedPackages` test ensuring classes like `java.lang.String` are still loaded by the bootstrap loader

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ff15862e8833386efed8399dc74b3