### PR TITLE
test: respect added excluded packages

### DIFF
--- a/src/test/java/com/plugin/loader/PluginClassLoaderTest.java
+++ b/src/test/java/com/plugin/loader/PluginClassLoaderTest.java
@@ -3,7 +3,10 @@ package com.plugin.loader;
 
 import org.junit.jupiter.api.Test;
 import java.net.URL;
+import java.lang.reflect.Method;
+import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PluginClassLoaderTest {
     @Test
@@ -16,5 +19,15 @@ public class PluginClassLoaderTest {
         PluginClassLoader classLoader = new PluginClassLoader(new URL[0], ClassLoader.getSystemClassLoader());
         Class<?> clazz = classLoader.loadClass("java.lang.String");
         assertNull(clazz.getClassLoader());
+    }
+
+    @Test
+    public void shouldRespectAddedExcludedPackages() throws Exception {
+        PluginClassLoader classLoader = new PluginClassLoader(new URL[0], ClassLoader.getSystemClassLoader());
+        classLoader.addExcludedPackages(Set.of("com.example."));
+        Method method = PluginClassLoader.class.getDeclaredMethod("isExcluded", String.class);
+        method.setAccessible(true);
+        boolean excluded = (boolean) method.invoke(classLoader, "com.example.Foo");
+        assertTrue(excluded);
     }
 }


### PR DESCRIPTION
## Summary
- add test to ensure PluginClassLoader respects excluded packages added at runtime

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ff5a333c48333896d9b71abe552bd