### PR TITLE
feat: allow dynamic plugin menu registration

### DIFF
--- a/fronted-web/main_project/module-federation.config.ts
+++ b/fronted-web/main_project/module-federation.config.ts
@@ -2,9 +2,7 @@ import { createModuleFederationConfig } from '@module-federation/rsbuild-plugin'
 
 export default createModuleFederationConfig({
   name: 'main_project',
-  remotes: {
-    plugin_project: 'plugin_project@http://localhost:3001/mf-manifest.json',
-  },
+  remotes: {},
   shareStrategy: 'loaded-first',
   shared: {
     react: { singleton: true },

--- a/fronted-web/main_project/module-federation.config.ts
+++ b/fronted-web/main_project/module-federation.config.ts
@@ -3,7 +3,7 @@ import { createModuleFederationConfig } from '@module-federation/rsbuild-plugin'
 export default createModuleFederationConfig({
   name: 'main_project',
   remotes: {
-    'provider': 'rslib_provider@./943a6b1b-222a-4e99-b900-3744270480e6/mf-manifest.json',
+    plugin_project: 'plugin_project@http://localhost:3001/mf-manifest.json',
   },
   shareStrategy: 'loaded-first',
   shared: {

--- a/fronted-web/main_project/package-lock.json
+++ b/fronted-web/main_project/package-lock.json
@@ -8,6 +8,7 @@
       "name": "main_project",
       "version": "1.0.0",
       "dependencies": {
+        "@module-federation/runtime": "^0.18.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -719,7 +720,6 @@
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.18.2.tgz",
       "integrity": "sha512-5240I1h/kMyU2N2ypg+CTJsqFk3micPm5JSZUdOV1eaqQCMqpOBAhWg0b/ZvsgB8tdaYi8cO2tXeSSn0tqI/uw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
@@ -863,7 +863,6 @@
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.18.2.tgz",
       "integrity": "sha512-ZtBQcyQ7Hi1RqEwJV+AIjlZPmwW+4xQU41GMbTfJDDl+Wms+YtfM904vuWDe1cbwJ94JJ5I6hyX7dyPmPqk8NA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "0.18.2",
@@ -875,7 +874,6 @@
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.18.2.tgz",
       "integrity": "sha512-49OrCMUdPz0kqTdF8yvrVNt0hf9vkyVa33ZFZjjoKdeQ6SlBdZk+1WjmaLd2bngqX38j7XxJgHrIC0ApsOlOLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "0.18.2",
@@ -897,7 +895,6 @@
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.18.2.tgz",
       "integrity": "sha512-sfvC43L1nA4U5HHQsLXeEenuE/0AMgHOEzHCICNZYvxvtHz3Pau6NK4hcQR5hGGpuIPweQilbQ0oAN8ZryvLdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/third-party-dts-extractor": {

--- a/fronted-web/main_project/package.json
+++ b/fronted-web/main_project/package.json
@@ -8,6 +8,7 @@
     "preview": "rsbuild preview"
   },
   "dependencies": {
+    "@module-federation/runtime": "^0.18.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/fronted-web/main_project/src/App.css
+++ b/fronted-web/main_project/src/App.css
@@ -13,3 +13,16 @@ body {
   flex-direction: column;
   justify-content: center;
 }
+
+.menu {
+  margin-bottom: 20px;
+}
+
+.menu button {
+  margin: 0 8px;
+  padding: 6px 12px;
+}
+
+.plugin-container {
+  margin-top: 20px;
+}

--- a/fronted-web/main_project/src/App.tsx
+++ b/fronted-web/main_project/src/App.tsx
@@ -1,10 +1,15 @@
 import React, { useEffect, useState } from 'react';
+import { loadRemote, registerRemotes } from '@module-federation/runtime';
 import './App.css';
 
 interface MenuItem {
   key: string;
   label: string;
   component: React.ComponentType;
+}
+
+interface PluginModule {
+  register(args: { registerMenu: (menu: MenuItem) => void }): void;
 }
 
 const App = () => {
@@ -17,11 +22,17 @@ const App = () => {
   };
 
   useEffect(() => {
-    import('plugin_project/plugin')
+    registerRemotes([
+      {
+        name: 'plugin_project',
+        entry: 'http://localhost:3001/mf-manifest.json',
+        type: 'mf-manifest',
+      },
+    ]);
+
+    loadRemote('plugin_project/plugin')
       .then((mod) => {
-        if (mod.register) {
-          mod.register({ registerMenu });
-        }
+        (mod as PluginModule | null)?.register({ registerMenu });
       })
       .catch((err) => {
         console.error('Failed to load plugin', err);

--- a/fronted-web/main_project/src/App.tsx
+++ b/fronted-web/main_project/src/App.tsx
@@ -1,13 +1,51 @@
+import React, { useEffect, useState } from 'react';
 import './App.css';
-import Provider from 'provider';
+
+interface MenuItem {
+  key: string;
+  label: string;
+  component: React.ComponentType;
+}
 
 const App = () => {
+  const [menus, setMenus] = useState<MenuItem[]>([]);
+  const [activeKey, setActiveKey] = useState<string>();
+
+  const registerMenu = (menu: MenuItem) => {
+    setMenus((prev) => [...prev, menu]);
+    setActiveKey((prev) => prev ?? menu.key);
+  };
+
+  useEffect(() => {
+    import('plugin_project/plugin')
+      .then((mod) => {
+        if (mod.register) {
+          mod.register({ registerMenu });
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load plugin', err);
+      });
+  }, []);
+
+  const ActiveComponent = menus.find((m) => m.key === activeKey)?.component;
+
   return (
     <div className="content">
-        <h1 className="title">我是主应用中的页面</h1>
-      <Provider />
+      <h1 className="title">我是主应用中的页面</h1>
+      <nav className="menu">
+        {menus.map((m) => (
+          <button key={m.key} onClick={() => setActiveKey(m.key)}>
+            {m.label}
+          </button>
+        ))}
+      </nav>
+      <div className="plugin-container">
+        {ActiveComponent ? <ActiveComponent /> : null}
+      </div>
     </div>
   );
 };
 
 export default App;
+

--- a/fronted-web/main_project/src/env.d.ts
+++ b/fronted-web/main_project/src/env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="@rsbuild/core/types" />
+declare module 'plugin_project/plugin' {
+  import type { ComponentType } from 'react';
+  export function register(args: {
+    registerMenu: (menu: { key: string; label: string; component: ComponentType }) => void;
+  }): void;
+}

--- a/fronted-web/main_project/src/env.d.ts
+++ b/fronted-web/main_project/src/env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="@rsbuild/core/types" />
-declare module 'plugin_project/plugin' {
-  import type { ComponentType } from 'react';
-  export function register(args: {
-    registerMenu: (menu: { key: string; label: string; component: ComponentType }) => void;
-  }): void;
-}

--- a/fronted-web/plugin_project/module-federation.config.ts
+++ b/fronted-web/plugin_project/module-federation.config.ts
@@ -3,7 +3,7 @@ import { createModuleFederationConfig } from '@module-federation/rsbuild-plugin'
 export default createModuleFederationConfig({
   name: 'plugin_project',
   exposes: {
-    '.': './src/components/ProviderComponent.tsx',
+    './plugin': './src/plugin.ts',
   },
   shared: {
     react: { singleton: true },

--- a/fronted-web/plugin_project/src/plugin.ts
+++ b/fronted-web/plugin_project/src/plugin.ts
@@ -1,0 +1,21 @@
+import type { ComponentType } from 'react';
+import Provider from './components/ProviderComponent';
+
+interface MenuItem {
+  key: string;
+  label: string;
+  component: ComponentType;
+}
+
+interface RegisterArgs {
+  registerMenu: (menu: MenuItem) => void;
+}
+
+export function register({ registerMenu }: RegisterArgs) {
+  registerMenu({
+    key: 'plugin',
+    label: '插件页面',
+    component: Provider,
+  });
+}
+


### PR DESCRIPTION
## Summary
- expose plugin registration entry for remote plugins
- load plugin at runtime and register menu in host app
- style host menu area

## Testing
- `cd fronted-web/plugin_project && npx tsc --noEmit && echo "plugin tsc ok" && cd ../main_project && npx tsc --noEmit && echo "main tsc ok" && cd ../../..`


------
https://chatgpt.com/codex/tasks/task_e_68a30989073c8333acaf0c80fa21f354